### PR TITLE
Upstream single element of reorderableListView fix

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -382,9 +382,6 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
 
     // Places the value from startIndex one space before the element at endIndex.
     void reorder(int startIndex, int endIndex) {
-      if (widget.children.length <= 1) {
-        return;
-      }
       setState(() {
         if (startIndex != endIndex)
           widget.onReorder(startIndex, endIndex);
@@ -577,6 +574,11 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
           );
           break;
       }
+
+      // If the reorderable list only has one child element, reordering
+      // should not be allowed.
+      final bool hasMoreThanOneChildElement = widget.children.length > 1;
+
       return SingleChildScrollView(
         scrollDirection: widget.scrollDirection,
         padding: widget.padding,
@@ -584,10 +586,10 @@ class _ReorderableListContentState extends State<_ReorderableListContent> with T
         reverse: widget.reverse,
         child: _buildContainerForScrollDirection(
           children: <Widget>[
-            if (widget.reverse) _wrap(finalDropArea, widget.children.length, constraints),
+            if (widget.reverse && hasMoreThanOneChildElement) _wrap(finalDropArea, widget.children.length, constraints),
             if (widget.header != null) widget.header,
             for (int i = 0; i < widget.children.length; i += 1) _wrap(widget.children[i], i, constraints),
-            if (!widget.reverse) _wrap(finalDropArea, widget.children.length, constraints),
+            if (!widget.reverse && hasMoreThanOneChildElement) _wrap(finalDropArea, widget.children.length, constraints),
           ],
         ),
       );


### PR DESCRIPTION
## Description

This addresses the reorder issue upstream from the original fix. This prevents a reorder on a single element while addressing the needs of the semantics framework.